### PR TITLE
feat: CLI型インターフェース（Ink + React）への移行を実装

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,18 @@
       "name": "miki",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@inkjs/ui": "^2.0.0",
         "dotenv": "^17.2.3",
+        "ink": "^6.6.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
         "openai": "^6.15.0",
+        "react": "^19.2.3",
         "zod": "^4.2.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/react": "^19.2.7",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -19,22 +25,120 @@
     },
   },
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],
+
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
+
+    "@inkjs/ui": ["@inkjs/ui@2.0.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-spinners": "^3.0.0", "deepmerge": "^4.3.1", "figures": "^6.1.0" }, "peerDependencies": { "ink": ">=5" } }, "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+
+    "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-spinners": ["cli-spinners@3.3.0", "", {}, "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ=="],
+
+    "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "es-toolkit": ["es-toolkit@1.43.0", "", {}, "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@6.6.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.1", "ansi-escapes": "^7.2.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^8.1.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": "^6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ=="],
+
+    "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
+
+    "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "openai": ["openai@6.15.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
     "zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
+
+    "ink-spinner/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,18 +4,25 @@
   "type": "module",
   "private": true,
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/react": "^19.2.7"
   },
   "peerDependencies": {
     "typescript": "^5"
   },
   "scripts": {
-    "start": "bun run src/controller/index.ts"
+    "start": "bun run src/cli/index.tsx",
+    "dev": "bun --hot run src/cli/index.tsx"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@inkjs/ui": "^2.0.0",
     "dotenv": "^17.2.3",
+    "ink": "^6.6.0",
+    "ink-spinner": "^5.0.0",
+    "ink-text-input": "^6.0.0",
     "openai": "^6.15.0",
+    "react": "^19.2.3",
     "zod": "^4.2.1"
   }
 }

--- a/src/cli/components/App.tsx
+++ b/src/cli/components/App.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { useAgent } from '../hooks/useAgent';
+import { LogPanel } from './LogPanel';
+import { InputPanel } from './InputPanel';
+import { StatusBar } from './StatusBar';
+
+export const App: React.FC = () => {
+  const { logs, status, runGoal, addHint } = useAgent();
+
+  const handleInputSubmit = (input: string) => {
+    if (status.state === 'idle' || status.state === 'completed') {
+      // 新規ゴールを開始
+      runGoal(input);
+    } else if (status.state === 'running') {
+      // 実行中のヒント追加
+      addHint(input);
+    }
+  };
+
+  return (
+    <Box flexDirection="column" height="100%">
+      {/* ヘッダー */}
+      <Box borderStyle="double" paddingX={1} marginBottom={1}>
+        <Text bold color="cyan">
+          🤖 miki - MacOS 自動操作エージェント CLI
+        </Text>
+      </Box>
+
+      {/* メインコンテンツエリア（スプリットビュー） */}
+      <Box flexDirection="column" flexGrow={1}>
+        {/* ログパネル（上部70%） */}
+        <Box flexDirection="column" flexGrow={7} borderStyle="single" marginBottom={1}>
+          <Box paddingX={1} borderStyle="single" borderBottom>
+            <Text bold color="yellow">📋 ログ</Text>
+          </Box>
+          <LogPanel logs={logs} />
+        </Box>
+
+        {/* 入力パネル（下部20%） */}
+        <Box flexDirection="column" flexGrow={2} marginBottom={1}>
+          <InputPanel state={status.state} onSubmit={handleInputSubmit} />
+        </Box>
+
+        {/* ステータスバー（最下部10%） */}
+        <Box flexDirection="column">
+          <StatusBar status={status} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/cli/components/InputPanel.tsx
+++ b/src/cli/components/InputPanel.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Box, Text } from 'ink';
+import TextInput from 'ink-text-input';
+import type { AgentState } from '../types';
+
+interface InputPanelProps {
+  state: AgentState;
+  onSubmit: (input: string) => void;
+}
+
+export const InputPanel: React.FC<InputPanelProps> = ({ state, onSubmit }) => {
+  const [value, setValue] = useState('');
+
+  const getPromptLabel = () => {
+    return state === 'idle' || state === 'completed' ? 'Goal: ' : 'Hint: ';
+  };
+
+  const getPromptColor = () => {
+    return state === 'idle' || state === 'completed' ? 'green' : 'yellow';
+  };
+
+  const handleSubmit = () => {
+    if (value.trim()) {
+      onSubmit(value.trim());
+      setValue('');
+    }
+  };
+
+  return (
+    <Box borderStyle="single" paddingX={1} flexDirection="column">
+      <Box>
+        <Text color={getPromptColor()} bold>{getPromptLabel()}</Text>
+        <TextInput
+          value={value}
+          onChange={setValue}
+          onSubmit={handleSubmit}
+          placeholder={state === 'idle' || state === 'completed' ? '実行したいタスクを入力してください...' : '追加のヒントを入力...'}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          {state === 'idle' || state === 'completed'
+            ? 'Enterキーで実行開始'
+            : '実行中にヒントを入力できます'}
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/src/cli/components/LogPanel.tsx
+++ b/src/cli/components/LogPanel.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { LogEntry } from '../types';
+
+interface LogPanelProps {
+  logs: LogEntry[];
+  maxLogs?: number;
+}
+
+export const LogPanel: React.FC<LogPanelProps> = ({ logs, maxLogs = 100 }) => {
+  const getLogColor = (type: LogEntry['type']) => {
+    switch (type) {
+      case 'info':
+        return 'white';
+      case 'success':
+        return 'green';
+      case 'error':
+        return 'red';
+      case 'hint':
+        return 'yellow';
+      case 'action':
+        return 'cyan';
+      default:
+        return 'white';
+    }
+  };
+
+  const getLogPrefix = (type: LogEntry['type']) => {
+    switch (type) {
+      case 'info':
+        return '[INFO]';
+      case 'success':
+        return '[SUCCESS]';
+      case 'error':
+        return '[ERROR]';
+      case 'hint':
+        return '[HINT]';
+      case 'action':
+        return '[ACTION]';
+      default:
+        return '';
+    }
+  };
+
+  // 最新のログのみ保持
+  const displayLogs = logs.slice(-maxLogs);
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      {displayLogs.length === 0 ? (
+        <Text dimColor>ログがまだありません。ゴールを入力して開始してください。</Text>
+      ) : (
+        displayLogs.map((log, index) => (
+          <Box key={`${log.timestamp.getTime()}-${index}`} marginBottom={0}>
+            <Text color={getLogColor(log.type)}>
+              <Text bold>{getLogPrefix(log.type)}</Text> {log.message}
+            </Text>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+};

--- a/src/cli/components/StatusBar.tsx
+++ b/src/cli/components/StatusBar.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { AgentStatus } from '../types';
+
+interface StatusBarProps {
+  status: AgentStatus;
+}
+
+export const StatusBar: React.FC<StatusBarProps> = ({ status }) => {
+  const getStatusColor = () => {
+    switch (status.state) {
+      case 'idle':
+        return 'gray';
+      case 'running':
+        return 'blue';
+      case 'completed':
+        return 'green';
+      case 'error':
+        return 'red';
+      default:
+        return 'white';
+    }
+  };
+
+  const getStatusText = () => {
+    switch (status.state) {
+      case 'idle':
+        return 'Idle';
+      case 'running':
+        return 'Running';
+      case 'completed':
+        return 'Completed';
+      case 'error':
+        return 'Error';
+      default:
+        return 'Unknown';
+    }
+  };
+
+  return (
+    <Box borderStyle="single" paddingX={1}>
+      <Text>
+        Step: <Text bold>{status.currentStep}/{status.maxSteps}</Text>
+        {' | '}
+        Status: <Text color={getStatusColor()} bold>{getStatusText()}</Text>
+        {status.currentGoal && (
+          <>
+            {' | '}
+            Goal: <Text dimColor>{status.currentGoal.slice(0, 50)}{status.currentGoal.length > 50 ? '...' : ''}</Text>
+          </>
+        )}
+      </Text>
+    </Box>
+  );
+};

--- a/src/cli/hooks/useAgent.ts
+++ b/src/cli/hooks/useAgent.ts
@@ -1,0 +1,110 @@
+import { useEffect, useState, useCallback } from 'react';
+import { MacOSAgent } from '../../controller/agent';
+import type { LogEntry, AgentState, AgentStatus } from '../types';
+
+export function useAgent() {
+  const [agent, setAgent] = useState<MacOSAgent | null>(null);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [status, setStatus] = useState<AgentStatus>({
+    state: 'idle',
+    currentStep: 0,
+    maxSteps: 20,
+  });
+
+  // エージェント初期化
+  useEffect(() => {
+    const newAgent = new MacOSAgent();
+
+    // ログイベントのリスナー
+    newAgent.on('log', (logEntry: LogEntry) => {
+      setLogs((prev) => [...prev, logEntry]);
+    });
+
+    // ステップイベントのリスナー
+    newAgent.on('step', (step: number) => {
+      setStatus((prev) => ({ ...prev, currentStep: step }));
+    });
+
+    // 完了イベントのリスナー
+    newAgent.on('completed', (message: string) => {
+      setStatus((prev) => ({ ...prev, state: 'completed' }));
+      setLogs((prev) => [...prev, {
+        type: 'success',
+        message: `タスク完了: ${message}`,
+        timestamp: new Date()
+      }]);
+    });
+
+    // 実行完了イベントのリスナー
+    newAgent.on('runCompleted', () => {
+      setStatus((prev) => ({ ...prev, state: 'idle', currentStep: 0 }));
+    });
+
+    // エラーイベントのリスナー
+    newAgent.on('error', (errorMessage: string) => {
+      setLogs((prev) => [...prev, {
+        type: 'error',
+        message: errorMessage,
+        timestamp: new Date()
+      }]);
+    });
+
+    // 初期化
+    newAgent.init().catch((err) => {
+      setLogs((prev) => [...prev, {
+        type: 'error',
+        message: `初期化失敗: ${err.message}`,
+        timestamp: new Date()
+      }]);
+    });
+
+    setAgent(newAgent);
+
+    // クリーンアップ
+    return () => {
+      newAgent.destroy();
+    };
+  }, []);
+
+  // ゴール実行
+  const runGoal = useCallback(
+    async (goal: string) => {
+      if (!agent) return;
+
+      setStatus((prev) => ({ ...prev, state: 'running', currentGoal: goal }));
+      setLogs((prev) => [...prev, {
+        type: 'info',
+        message: `新しいゴールを開始: ${goal}`,
+        timestamp: new Date()
+      }]);
+
+      try {
+        await agent.run(goal);
+      } catch (error: any) {
+        setLogs((prev) => [...prev, {
+          type: 'error',
+          message: `実行エラー: ${error.message}`,
+          timestamp: new Date()
+        }]);
+        setStatus((prev) => ({ ...prev, state: 'error' }));
+      }
+    },
+    [agent]
+  );
+
+  // ヒント追加
+  const addHint = useCallback(
+    (hint: string) => {
+      if (!agent) return;
+      agent.addHint(hint);
+    },
+    [agent]
+  );
+
+  return {
+    logs,
+    status,
+    runGoal,
+    addHint,
+  };
+}

--- a/src/cli/index.tsx
+++ b/src/cli/index.tsx
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+import React from 'react';
+import { render } from 'ink';
+import { App } from './components/App';
+import * as dotenv from 'dotenv';
+
+// 環境変数の読み込み
+dotenv.config();
+
+// Inkアプリケーションをレンダリング
+const { unmount, waitUntilExit } = render(<App />);
+
+// プロセス終了時のクリーンアップ
+process.on('SIGINT', () => {
+  unmount();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  unmount();
+  process.exit(0);
+});
+
+// アプリケーションの終了を待つ
+await waitUntilExit();

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,18 @@
+// CLI固有の型定義
+
+export type LogType = 'info' | 'success' | 'error' | 'hint' | 'action';
+
+export interface LogEntry {
+  type: LogType;
+  message: string;
+  timestamp: Date;
+}
+
+export type AgentState = 'idle' | 'running' | 'completed' | 'error';
+
+export interface AgentStatus {
+  state: AgentState;
+  currentStep: number;
+  maxSteps: number;
+  currentGoal?: string;
+}

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,3 +1,9 @@
+// ⚠️ このファイルは非推奨です
+// CLI型インターフェースに移行しました。
+// 新しいエントリーポイントは src/cli/index.tsx です。
+// `bun run start` で起動してください。
+
+/*
 import * as dotenv from "dotenv";
 import { MacOSAgent } from "./agent";
 
@@ -12,4 +18,5 @@ async function main() {
 }
 
 main().catch(console.error);
+*/
 


### PR DESCRIPTION
スプリットビュー、REPL対応、リアルタイムログ表示を実現

主な変更:
- Ink（React for CLI）を導入し、スプリットビューUIを実装
- MacOSAgentをEventEmitter化し、イベント駆動のログ配信を実装
- REPL対応: タスク完了後も次のゴールを受付可能
- 実行中のヒント入力機能を維持

新規ファイル:
- src/cli/index.tsx: CLIエントリーポイント
- src/cli/components/App.tsx: メインレイアウト
- src/cli/components/LogPanel.tsx: ログ表示パネル
- src/cli/components/InputPanel.tsx: 入力パネル
- src/cli/components/StatusBar.tsx: ステータスバー
- src/cli/hooks/useAgent.ts: エージェント制御フック
- src/cli/types.ts: CLI固有の型定義

変更ファイル:
- src/controller/agent.ts: EventEmitter継承、ログイベント発火、REPL対応
- src/controller/index.ts: 非推奨化（CLI移行）
- package.json: スクリプト変更、Ink関連依存追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)