### PR TITLE
chore: remove redundant comments across executor and controller modules

### DIFF
--- a/src/controller/cache-manager.ts
+++ b/src/controller/cache-manager.ts
@@ -6,9 +6,9 @@ import type { CacheMetadata } from "./types";
 export class GeminiCacheManager {
   private cacheManager: any;
   private apiKey: string;
-  private modelName: string = "gemini-3-flash-preview"; // Default model for caching
+  private modelName: string = "gemini-3-flash-preview";
   private systemPromptCache: CacheMetadata | null = null;
-  private historyCache: CacheMetadata | null = null; // 履歴を含むキャッシュ
+  private historyCache: CacheMetadata | null = null;
   private uiElementsCaches: Map<string, CacheMetadata> = new Map();
 
   constructor(apiKey: string) {
@@ -32,7 +32,6 @@ export class GeminiCacheManager {
     try {
       this.modelName = model;
       
-      // キャッシュを作成
       const cache = await this.cacheManager.create({
         model: model,
         displayName: "miki-system-prompt",
@@ -43,20 +42,19 @@ export class GeminiCacheManager {
           },
         ],
         tools: tools ? [{ functionDeclarations: tools }] : undefined,
-        ttlSeconds: 3600, // 1時間キャッシュ
+        ttlSeconds: 3600,
       });
 
       this.systemPromptCache = {
         cacheName: cache.name,
         createdAt: cache.createTime,
         expiresAt: cache.expireTime,
-        tokenCount: 0, // SDKから取得できない場合は0
+        tokenCount: 0,
       };
 
       console.error(`System prompt cache created: ${cache.name}`);
       return this.systemPromptCache;
     } catch (error: any) {
-      // 1024トークン未満などの理由でキャッシュに失敗した場合は無視する
       if (error?.message?.includes("too small") || error?.status === 400) {
         console.error("System prompt is too small for caching. Skipping.");
       } else {
@@ -79,7 +77,6 @@ export class GeminiCacheManager {
     try {
       this.modelName = model;
       
-      // 古い履歴キャッシュを削除（オプション。Geminiは自動で消去するが明示的に管理）
       if (this.historyCache) {
         await this.deleteCache(this.historyCache.cacheName).catch(() => {});
       }
@@ -89,7 +86,7 @@ export class GeminiCacheManager {
         displayName: "miki-history-cache",
         contents: contents,
         tools: tools ? [{ functionDeclarations: tools }] : undefined,
-        ttlSeconds: 1800, // 30分
+        ttlSeconds: 1800,
       });
 
       this.historyCache = {
@@ -133,7 +130,7 @@ export class GeminiCacheManager {
             parts: [{ text: `Below is the UI structure for the application: ${appName}\n\n${dataStr}` }],
           },
         ],
-        ttlSeconds: 300, // 5分キャッシュ
+        ttlSeconds: 300,
       });
 
       const metadata = {

--- a/src/controller/types.ts
+++ b/src/controller/types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// UI要素の型定義
 export interface UIElement {
   role: string;
   roleDescription: string;
@@ -12,7 +11,7 @@ export interface UIElement {
   enabled: boolean;
   focused: boolean;
   selected: boolean;
-  actions: string[]; // "AXPress", "AXFocus"等
+  actions: string[];
   subrole: string;
   children: UIElement[];
 }
@@ -21,7 +20,6 @@ export interface UIElementsResponse {
   windows: UIElement[];
 }
 
-// アクションの定義（Geminiの構造化出力に使用）
 export const ActionSchemaBase = z.discriminatedUnion("action", [
   z.object({ action: z.literal("screenshot") }),
   z.object({ action: z.literal("click"), params: z.object({ x: z.number(), y: z.number() }) }),
@@ -123,7 +121,6 @@ export interface PythonResponse {
   execution_time_ms?: number;
 }
 
-// キャッシュ関連の型定義
 export interface CacheMetadata {
   cacheName: string;
   createdAt: string;

--- a/src/executor/actions/__init__.py
+++ b/src/executor/actions/__init__.py
@@ -1,1 +1,0 @@
-# Action modules for executor

--- a/src/executor/main.py
+++ b/src/executor/main.py
@@ -10,12 +10,10 @@ import time
 import pyautogui
 import io
 
-# 標準入出力をUTF-8に設定
 sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
 sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', line_buffering=True)
 
-# 各アクションモジュールをインポート
 from actions.screenshot import screenshot, get_screen_size
 from actions.mouse_keyboard import (
     click, type_text, press_key, hotkey,
@@ -32,7 +30,6 @@ from actions.web_elements import get_web_elements, get_default_browser
 pyautogui.FAILSAFE = True
 
 
-# アクションディスパッチャー: アクション名から実装関数へのマッピング
 ACTION_HANDLERS = {
     "screenshot": screenshot,
     "click": click,
@@ -75,14 +72,11 @@ def main():
             action = command_data.get("action")
             params = command_data.get("params", {})
 
-            # exitアクションは特別扱い
             if action == "exit":
                 break
 
-            # アクションを実行
             result = dispatch_action(action, params)
 
-            # 実行時間を追加
             end_time = time.time()
             result["execution_time_ms"] = int((end_time - start_time) * 1000)
 

--- a/src/executor/utils/__init__.py
+++ b/src/executor/utils/__init__.py
@@ -1,1 +1,0 @@
-# Utility modules for executor

--- a/src/executor/utils/coordinate_helper.py
+++ b/src/executor/utils/coordinate_helper.py
@@ -8,7 +8,6 @@ def calculate_scale_factors():
     Retina等でのスクリーンショットと論理座標の差を考慮
     """
     screen_w, screen_h = pyautogui.size()
-    # 実際のスクリーンショットのサイズを取得
     shot = pyautogui.screenshot()
     img_w, img_h = shot.size
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary comment noise across the codebase to improve readability while preserving intent and required documentation.
- Focus changes on executor and controller modules where many obvious or duplicated inline comments were present.
- Ensure no behavioral changes by only deleting non-essential comments and preserving functional code.
- Keep `src/controller/constants.ts` untouched as a deliberate exception.

### Description
- Removed redundant single-line and header comments from Python executor files including `src/executor/main.py`, `src/executor/utils/__init__.py`, and `src/executor/actions/__init__.py`.
- Trimmed an obvious comment line in `src/executor/utils/coordinate_helper.py` and simplified inline comments in `src/controller/cache-manager.ts` and `src/controller/types.ts` while keeping type and logic definitions intact.
- No code logic or signatures were modified; the edits are limited to comment removal and minor whitespace/formatting adjustments.
- Confirmed that `src/controller/constants.ts` was not modified.

### Testing
- No automated tests were executed for these comment-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fad4dea1c832692427d57d3cb1a40)