### PR TITLE
chore: add CONTRIBUTING guide and MIT License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to miki desktop
+
+Thanks for your interest in contributing! This project welcomes bug reports, feature requests, and pull requests.
+
+## Getting Started
+
+- Review the project overview and architecture docs in `docs/`.
+- Use the integrated CLI `./dev.sh` for setup and development.
+- Prefer Bun for Node tasks (`bun run ...`) as described in the README.
+
+## Development Setup
+
+```bash
+./dev.sh doctor
+./dev.sh install
+./dev.sh setup-python
+./dev.sh build-all
+./dev.sh start
+```
+
+If the interactive menu does not work in your environment, use the subcommands listed in the README (for example `bun --cwd desktop run dev`).
+
+## Coding Standards
+
+- Follow existing code style and patterns in each directory.
+- Keep CommonJS in `desktop/` (`require` / `module.exports`).
+- JSON/HTML use 2-space indentation; JS follows existing double quotes.
+- Avoid adding temporary helper scripts; prefer existing Bun scripts.
+
+## Pull Requests
+
+- Keep PRs focused and describe the behavior change.
+- Add screenshots for renderer UI changes (`desktop/renderer/`).
+- Include related issue links when available.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 miki contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ You can send requests directly to AI from the chat window.
 
 For a detailed explanation of the system architecture, see the [Architecture documentation](./docs/ARCHITECTURE.md).
 
+## Contributing
+
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for setup steps, coding standards, and PR guidelines.
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).
+
 ## Security Notes
 
 - `desktop/renderer/index.html` and `desktop/renderer/chat.html` use Tailwind CDN,


### PR DESCRIPTION
### Motivation
- Prepare the repository for open-source contribution by adding a contributor guide and an explicit MIT license so external contributors have clear setup, coding standards, and licensing information.

### Description
- Add `CONTRIBUTING.md` with setup steps, development commands, coding standards, and PR guidelines, add `LICENSE` containing the MIT license text, and update `README.md` to link to `CONTRIBUTING.md` and `LICENSE` for discoverability.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69673733123c83269c82ef63c58c313b)